### PR TITLE
Send API event tracking to a second Google Analytics account

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -47,6 +47,23 @@ class GAApiController(ApiController):
             }
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
+        if config.get('googleanalytics.id2'):
+            data_dict_2 = {
+                "v": 1,
+                "tid": config.get('googleanalytics.id2'),
+                "cid": hashlib.md5(user).hexdigest(),
+                # customer id should be obfuscated
+                "t": "event",
+                "dh": c.environ['HTTP_HOST'],
+                "dp": c.environ['PATH_INFO'],
+                "dr": c.environ.get('HTTP_REFERER', ''),
+                "ec": "CKAN API Request",
+                "ea": request_obj_type+request_function,
+                "el": request_id,
+            }
+            plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict_2)
+
+
     def action(self, logic_function, ver=None):
         try:
             function = logic.get_action(logic_function)

--- a/ckanext/googleanalytics/plugin.py
+++ b/ckanext/googleanalytics/plugin.py
@@ -42,6 +42,22 @@ def _post_analytics(
         }
         GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
+    if config.get('googleanalytics.id2'):
+        data_dict_2 = {
+            "v": 1,
+            "tid": config.get('googleanalytics.id2'),
+            "cid": hashlib.md5(c.user).hexdigest(),
+            # customer id should be obfuscated
+            "t": "event",
+            "dh": c.environ['HTTP_HOST'],
+            "dp": c.environ['PATH_INFO'],
+            "dr": c.environ.get('HTTP_REFERER', ''),
+            "ec": event_type,
+            "ea": request_obj_type + request_function,
+            "el": request_id,
+        }
+        GoogleAnalyticsPlugin.analytics_queue.put(data_dict_2)
+
 
 def post_analytics_decorator(func):
 


### PR DESCRIPTION
**Introduction:**
Currently the extension allows a second Google Analytics account to be sent page view details. However, events like resource downloads and API calls are not sent to the second account. This PR will fix it so that those event tracking is sent to the second Google Analytics account as well.

**Change:**
Send events to a second Google Analytics id if it is defined in the CKAN ini file. The second id is set with the configuration `googleanalytics.id2`.