### PR TITLE
[OD-600] Google Analytics prevents creating datasets on Production Sites

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -203,16 +203,30 @@ class GAPackageController(PackageController):
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
     def read(self, id):
+        logging.error('read has been called')
+#        return
         org_id = self.get_package_org_id(id)
-        self._post_analytics(c.user,"Organization","View",org_id)
+        if org_id != "new":
+            self._post_analytics(c.user,"Organization","View",org_id)
+        else:
+            return PackageController.new(self)
         return PackageController.read(self, id)
 
     def resource_read(self, id, resource_id):
+        logging.error('resource_read has been called')
         org_id = self.get_package_org_id(id)
         self._post_analytics(c.user,"Organization","View",org_id)
         return PackageController.resource_read(self, id, resource_id)
 
     def get_package_org_id(self, package_id):
-        package = toolkit.get_action('package_show')({},{'id':package_id})
-        org_id = package.get('organization').get('title')
+        logging.error('package id: ' + package_id)
+        try:
+            package = toolkit.get_action('package_show')({},{'id':package_id})
+            org_id = package.get('organization').get('title')
+        except:
+            org_id = "new"
         return org_id
+
+#    def edit(self,id):
+#	logging.error('edit called')
+#	return PackageController.edit(self,id)

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -202,11 +202,13 @@ class GAPackageController(PackageController):
             }
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
+    # This function is called everytime we access a dataset including the dataset "new" when creating a new datasets
     def read(self, id):
-        logging.error('read has been called')
+        # We do not want to incorrectly perform read operation on package id "new", where it results in the package not being found
         if id!="new":
             org_id = self.get_package_org_id(id)
             self._post_analytics(c.user,"Organization","View",org_id)
+        # If we simply return PackageController.read() or return w/o a PackaageController.new() operation, a blank page or error page will appear
         else:
             return PackageController.new(self)
         return PackageController.read(self, id)

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -204,29 +204,19 @@ class GAPackageController(PackageController):
 
     def read(self, id):
         logging.error('read has been called')
-#        return
-        org_id = self.get_package_org_id(id)
-        if org_id != "new":
+        if id!="new":
+            org_id = self.get_package_org_id(id)
             self._post_analytics(c.user,"Organization","View",org_id)
         else:
             return PackageController.new(self)
         return PackageController.read(self, id)
 
     def resource_read(self, id, resource_id):
-        logging.error('resource_read has been called')
         org_id = self.get_package_org_id(id)
         self._post_analytics(c.user,"Organization","View",org_id)
         return PackageController.resource_read(self, id, resource_id)
 
     def get_package_org_id(self, package_id):
-        logging.error('package id: ' + package_id)
-        try:
-            package = toolkit.get_action('package_show')({},{'id':package_id})
-            org_id = package.get('organization').get('title')
-        except:
-            org_id = "new"
+        package = toolkit.get_action('package_show')({},{'id':package_id})
+        org_id = package.get('organization').get('title')
         return org_id
-
-#    def edit(self,id):
-#	logging.error('edit called')
-#	return PackageController.edit(self,id)


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
[[OD-540] Add support for urls in CKAN file upload script](https://opengovinc.atlassian.net/secure/RapidBoard.jspa?rapidView=82&projectKey=OD&view=planning&selectedIssue=OD-600)

## Description
**Introduction**
This PR is to fix a bug caused by the Google Analytics extension preventing new datasets from being created. Currently when trying to add a new dataset, the following error occurs:

```
"SERVER ERROR
An internal server error occurred"

```
This is being caused by the fact the controller.py performs always read operation within the class GAPackageController(PackageController), including when trying to create a new dataset. From my understanding, the read operation occurs on every dataset so we can pass information to Google Analytics regarding the dataset for collection. When this operation occurs for creating a new dataset, the package id "new" is passed, but cannot be found by subsequent operations, such as finding the organization, a package with the id "new" cannot be found and thus causes an exception to be thrown in CKAN. To fix this bug, it appears we need to prevent the "read" operation from occurring when we try to create a new dataset.

**Note:** The current state of the fix I implemented may not be the best final approach to resolving this bug since it relies on the CKAN backend to use conditional statements to account for the specific situation where we try to create a new dataset. Instead, I believe ideally, we won't incorrectly perform a read operation at all when we create a new dataset.
 


**Changes:**
- Modified controller.py so that when the read operation occurs, we use condition statement on the package id so if it is "new" we do not attempt to get its organization information or post it to Google Analytics. 
- Modified controller.py so that we do not perform `PackageController.read` when the package id is "new", instead we perform a `PackageController.new` operation

## Test Procedure & Approval Criteria 
**Test Procedures:**
- Install the Google Analytics Extension from the datasetcreationfix branch on your VM
- When attempting to create a new dataset, you should not see an internal server error appear when clicking add dataset
- Verify that the dataset can be successfully created by populating it with information
- If you have a Google Analytics account, you can verify that the new dataset appears in your Google Analytics dashboard and see if the count for views for your newly created dataset appears such as for [CHHS staging ](https://analytics.google.com/analytics/web/#/report-home/a120903498w178679524p177140092/)

## Submitter Checklist
- [x] I have checked the README file and updated it when necessary
- [x] I have tested the changes locally

## Reviewer Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If any of the following checkboxes don't apply, simply strike them out: ~~ ... ~~ --->
- [ ] I have run this code change locally
- [ ] The description clearly states the impact of this code change.
- [ ] There is enough information to verify the functionality