### PR TITLE
[OD-720] Google Analytics throws internal server error on CKAN during org creation

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -178,10 +178,20 @@ class GAOrganizationController(OrganizationController):
             }
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
+    # def read(self, id, limit=20):
+    #     org = toolkit.get_action('organization_show')({},{'id':id})
+    #     org_title = org.get('title')
+    #     self._post_analytics(c.user,"Organization","View",org_title)
+    #     return OrganizationController.read(self, id, limit=20)
+
     def read(self, id, limit=20):
-        org = toolkit.get_action('organization_show')({},{'id':id})
-        org_title = org.get('title')
-        self._post_analytics(c.user,"Organization","View",org_title)
+        # We do not want to incorrectly perform read operation on organization id "new", where it results in a NotFound error 
+        if id!="new":
+            org = toolkit.get_action('organization_show')({},{'id':id})
+            org_title = org.get('title')
+            self._post_analytics(c.user,"Organization","View",org_title)
+        else:
+            return OrganizationController.new(self)
         return OrganizationController.read(self, id, limit=20)
 
 class GAPackageController(PackageController):

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -178,12 +178,6 @@ class GAOrganizationController(OrganizationController):
             }
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
-    # def read(self, id, limit=20):
-    #     org = toolkit.get_action('organization_show')({},{'id':id})
-    #     org_title = org.get('title')
-    #     self._post_analytics(c.user,"Organization","View",org_title)
-    #     return OrganizationController.read(self, id, limit=20)
-
     def read(self, id, limit=20):
         # We do not want to incorrectly perform read operation on organization id "new", where it results in a NotFound error 
         if id!="new":


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
[[OD-720] Google Analytics throws internal server error on CKAN during org creation](https://opengovinc.atlassian.net/secure/RapidBoard.jspa?rapidView=82&projectKey=OD&view=planning&selectedIssue=OD-600)

## Description
**Introduction**
This PR is to fix a bug caused by the Google Analytics extension preventing new organizations from being created and throws an internal server error on CKAN. This is being caused by a read operation being done on the organization id "new".


**Changes:**

- Modified controller.py so that we do not perform `OrganizationController.read` when the orgnanization id is "new", instead we perform a `OrganizationController.new` operation

## Test Procedure & Approval Criteria 
**Test Procedures:**
- Install the Google Analytics Extension from this branch on your VM
- When attempting to create a new organization, you should not see an internal server error appear when clicking add organization
- Verify that the organization  can be successfully created by populating its metadata with information
- If you have a Google Analytics account, you can verify that the new organization appears in your Google Analytics dashboard (I tested this using CHHS google analytics account and saw the new organization appear)

## Submitter Checklist
- [x] I have checked the README file and updated it when necessary
- [x] I have tested the changes locally

## Reviewer Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If any of the following checkboxes don't apply, simply strike them out: ~~ ... ~~ --->
- [x] I have run this code change locally
- [x] The description clearly states the impact of this code change.
- [x] There is enough information to verify the functionality