### PR TITLE
[OD-763] Fix dataset NotFound error in Google Analytics extension

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -182,9 +182,12 @@ class GAOrganizationController(OrganizationController):
         # We do not want to perform read operation on organization id "new",
         # where it results in a NotFound error
         if id!="new":
-            org = toolkit.get_action('organization_show')({},{'id':id})
-            org_title = org.get('title')
-            self._post_analytics(c.user,"Organization", "View", org_title)
+            try:
+                org = toolkit.get_action('organization_show')({},{'id':id})
+                org_title = org.get('title')
+                self._post_analytics(c.user,"Organization", "View", org_title)
+            except:
+                log.debug('Organization not found: ' + id)
         else:
             return OrganizationController.new(self)
         return OrganizationController.read(self, id, limit=20)

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -179,11 +179,12 @@ class GAOrganizationController(OrganizationController):
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
     def read(self, id, limit=20):
-        # We do not want to incorrectly perform read operation on organization id "new", where it results in a NotFound error 
+        # We do not want to perform read operation on organization id "new",
+        # where it results in a NotFound error
         if id!="new":
             org = toolkit.get_action('organization_show')({},{'id':id})
             org_title = org.get('title')
-            self._post_analytics(c.user,"Organization","View",org_title)
+            self._post_analytics(c.user,"Organization", "View", org_title)
         else:
             return OrganizationController.new(self)
         return OrganizationController.read(self, id, limit=20)
@@ -206,23 +207,32 @@ class GAPackageController(PackageController):
             }
             plugin.GoogleAnalyticsPlugin.analytics_queue.put(data_dict)
 
-    # This function is called everytime we access a dataset including the dataset "new" when creating a new datasets
+    # This function is called everytime we access a dataset including
+    # the dataset "new" when creating a new datasets
     def read(self, id):
-        # We do not want to incorrectly perform read operation on package id "new", where it results in the package not being found
+        # We do not want to perform read operation on package id "new",
+        # where it results in the package not being found
         if id!="new":
             org_id = self.get_package_org_id(id)
-            self._post_analytics(c.user,"Organization","View",org_id)
-        # If we simply return PackageController.read() or return w/o a PackaageController.new() operation, a blank page or error page will appear
+            if org_id:
+                self._post_analytics(c.user, "Organization", "View", org_id)
+        # If we simply return PackageController.read() or return w/o a
+        # PackageController.new() operation, a blank page or error page will appear
         else:
             return PackageController.new(self)
         return PackageController.read(self, id)
 
     def resource_read(self, id, resource_id):
         org_id = self.get_package_org_id(id)
-        self._post_analytics(c.user,"Organization","View",org_id)
+        if org_id:
+            self._post_analytics(c.user, "Organization", "View", org_id)
         return PackageController.resource_read(self, id, resource_id)
 
     def get_package_org_id(self, package_id):
-        package = toolkit.get_action('package_show')({},{'id':package_id})
-        org_id = package.get('organization').get('title')
+        org_id = ''
+        try:
+            package = toolkit.get_action('package_show')({},{'id':package_id})
+            org_id = package.get('organization').get('title')
+        except:
+            log.debug('Dataset not found: ' + package_id)
         return org_id


### PR DESCRIPTION
When a user visits a url pointing to a non-existent dataset a server error is returned instead of a 404 error. The cause is that the google analytics extension checks what organization a dataset belongs to before it checks if the dataset exists.

Acceptance Criteria:
* A user visiting the url of a non-existent dataset "/dataset/{non-existent dataset}" should see a 404 error page