### PR TITLE
[OD-1784] Handle NotFound and NotAuthorized exceptions

### DIFF
--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -189,7 +189,6 @@ class GAOrganizationController(OrganizationController):
             self._post_analytics(c.user, "Organization", "View", org_title)
         except Exception as e:
             log.debug(e)
-            pass
         return OrganizationController.read(self, id, limit=20)
 
 
@@ -239,7 +238,6 @@ class GAPackageController(PackageController):
                 self._post_analytics(c.user, "Organization", "View", org_id)
         except Exception as e:
             log.debug(e)
-            pass
         return PackageController.read(self, id)
 
     def resource_read(self, id, resource_id):
@@ -249,7 +247,6 @@ class GAPackageController(PackageController):
                 self._post_analytics(c.user, "Organization", "View", org_id)
         except Exception as e:
             log.debug(e)
-            pass
         return PackageController.resource_read(self, id, resource_id)
 
     def get_package_org_id(self, package_id):
@@ -259,7 +256,6 @@ class GAPackageController(PackageController):
             org_id = package.get('organization', {}).get('title')
         except Exception as e:
             log.debug(e)
-            pass
         return org_id
 
 

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -181,15 +181,15 @@ class GAOrganizationController(OrganizationController):
     def read(self, id, limit=20):
         # We do not want to perform read operation on organization id "new",
         # where it results in a NotFound error
-        if id and id != "new":
-            try:
-                org = toolkit.get_action('organization_show')({},{'id':id})
-                org_title = org.get('title')
-                self._post_analytics(c.user, "Organization", "View", org_title)
-            except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
-                pass
-        elif id == "new":
+        if id == "new":
             return OrganizationController.new(self)
+        try:
+            org = toolkit.get_action('organization_show')({}, {'id': id})
+            org_title = org.get('title')
+            self._post_analytics(c.user, "Organization", "View", org_title)
+        except Exception as e:
+            log.debug(e)
+            pass
         return OrganizationController.read(self, id, limit=20)
 
 
@@ -231,28 +231,34 @@ class GAPackageController(PackageController):
     def read(self, id):
         # We do not want to perform read operation on package id "new",
         # where it results in the package not being found
-        if id != "new":
+        if id == "new":
+            return PackageController.new(self)
+        try:
             org_id = self.get_package_org_id(id)
             if org_id:
                 self._post_analytics(c.user, "Organization", "View", org_id)
-        # If we simply return PackageController.read() or return w/o a
-        # PackageController.new() operation, a blank page or error page will appear
-        elif id == "new":
-            return PackageController.new(self)
+        except Exception as e:
+            log.debug(e)
+            pass
         return PackageController.read(self, id)
 
     def resource_read(self, id, resource_id):
-        org_id = self.get_package_org_id(id)
-        if org_id:
-            self._post_analytics(c.user, "Organization", "View", org_id)
+        try:
+            org_id = self.get_package_org_id(id)
+            if org_id:
+                self._post_analytics(c.user, "Organization", "View", org_id)
+        except Exception as e:
+            log.debug(e)
+            pass
         return PackageController.resource_read(self, id, resource_id)
 
     def get_package_org_id(self, package_id):
         org_id = ''
         try:
             package = toolkit.get_action('package_show')({}, {'id': package_id})
-            org_id = package.get('organization').get('title')
-        except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
+            org_id = package.get('organization', {}).get('title')
+        except Exception as e:
+            log.debug(e)
             pass
         return org_id
 

--- a/ckanext/googleanalytics/controller.py
+++ b/ckanext/googleanalytics/controller.py
@@ -181,14 +181,14 @@ class GAOrganizationController(OrganizationController):
     def read(self, id, limit=20):
         # We do not want to perform read operation on organization id "new",
         # where it results in a NotFound error
-        if id != "new":
+        if id and id != "new":
             try:
                 org = toolkit.get_action('organization_show')({},{'id':id})
                 org_title = org.get('title')
                 self._post_analytics(c.user, "Organization", "View", org_title)
-            except Exception:
-                log.debug('Organization not found: ' + id)
-        else:
+            except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
+                pass
+        elif id == "new":
             return OrganizationController.new(self)
         return OrganizationController.read(self, id, limit=20)
 
@@ -237,7 +237,7 @@ class GAPackageController(PackageController):
                 self._post_analytics(c.user, "Organization", "View", org_id)
         # If we simply return PackageController.read() or return w/o a
         # PackageController.new() operation, a blank page or error page will appear
-        else:
+        elif id == "new":
             return PackageController.new(self)
         return PackageController.read(self, id)
 
@@ -252,8 +252,8 @@ class GAPackageController(PackageController):
         try:
             package = toolkit.get_action('package_show')({}, {'id': package_id})
             org_id = package.get('organization').get('title')
-        except Exception:
-            log.debug('Dataset not found: ' + package_id)
+        except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
+            pass
         return org_id
 
 

--- a/ckanext/googleanalytics/plugin/pylons_plugin.py
+++ b/ckanext/googleanalytics/plugin/pylons_plugin.py
@@ -154,8 +154,10 @@ def wrap_resource_download(func):
             package_id = resource_dict.get('package_id')
             package_dict = tk.get_action('package_show')({}, {'id': package_id})
             package_name = package_dict.get('name')
-            organization_id = package_dict.get('organization').get('id')
-            organization_title = package_dict.get('organization').get('title')
+            organization_id = package_dict.get('organization', {}).get('id')
+            organization_title = package_dict.get('organization', {}).get('title')
+        except tk.ValidationError as error:
+            return tk.abort(400, error.message)
         except (tk.ObjectNotFound, tk.NotAuthorized):
             return tk.abort(404, _('Resource not found'))
 

--- a/ckanext/googleanalytics/plugin/pylons_plugin.py
+++ b/ckanext/googleanalytics/plugin/pylons_plugin.py
@@ -12,7 +12,10 @@ from ckan.controllers.package import PackageController
 from pylons import config
 from routes.mapper import SubMapper
 
+
 log = logging.getLogger(__name__)
+
+_ = tk._
 
 
 class GAMixinPlugin(plugins.SingletonPlugin):
@@ -145,13 +148,16 @@ class GAMixinPlugin(plugins.SingletonPlugin):
 
 def wrap_resource_download(func):
     def func_wrapper(cls, id, resource_id, filename=None):
-        resource_dict = tk.get_action('resource_show')({}, {'id': resource_id})
-        resource_name = resource_dict.get('name')
-        package_id = resource_dict.get('package_id')
-        package_dict = tk.get_action('package_show')({}, {'id': package_id})
-        package_name = package_dict.get('name')
-        organization_id = package_dict.get('organization').get('id')
-        organization_title = package_dict.get('organization').get('title')
+        try:
+            resource_dict = tk.get_action('resource_show')({}, {'id': resource_id})
+            resource_name = resource_dict.get('name')
+            package_id = resource_dict.get('package_id')
+            package_dict = tk.get_action('package_show')({}, {'id': package_id})
+            package_name = package_dict.get('name')
+            organization_id = package_dict.get('organization').get('id')
+            organization_title = package_dict.get('organization').get('title')
+        except (tk.ObjectNotFound, tk.NotAuthorized):
+            return tk.abort(404, _('Resource not found'))
 
         try:
             resource_alias = resource_id

--- a/ckanext/googleanalytics/views.py
+++ b/ckanext/googleanalytics/views.py
@@ -139,6 +139,10 @@ def before_organization_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         org_id = args.get('id', '')
+
+        if org_id == 'new':
+            return
+
         try:
             org_dict = tk.get_action('organization_show')({},{'id': org_id})
             org_title = org_dict.get('title')
@@ -160,7 +164,7 @@ ga_organization = Blueprint(
                   u'is_organization': True}
 )
 ga_organization.before_request(before_organization_request)
-ga_organization.add_url_rule(u'/new', methods=[u'GET'], view_func=group.CreateGroupView.as_view('new'))
+ga_organization.add_url_rule(u'/new', view_func=group.CreateGroupView.as_view('new'))
 ga_organization.add_url_rule(u'/<id>', methods=[u'GET'], view_func=group.read)
 
 
@@ -168,19 +172,22 @@ def before_dataset_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         package_id = args.get('id', '')
-        if package_id and package_id != 'new':
-            try:
-                package_dict = tk.get_action('package_show')({}, {'id': package_id})
-                org_title = package_dict.get('organization', {}).get('title')
-                _post_analytics(
-                    tk.c.user,
-                    "CKAN Organization Page View",
-                    "Organization",
-                    "View",
-                    org_title
-                )
-            except Exception as e:
-                log.debug(e)
+
+        if package_id == 'new':
+            return
+
+        try:
+            package_dict = tk.get_action('package_show')({}, {'id': package_id})
+            org_title = package_dict.get('organization', {}).get('title')
+            _post_analytics(
+                tk.c.user,
+                "CKAN Organization Page View",
+                "Organization",
+                "View",
+                org_title
+            )
+        except Exception as e:
+            log.debug(e)
 
 ga_dataset = Blueprint(
     u'dataset_googleanalytics',
@@ -189,7 +196,7 @@ ga_dataset = Blueprint(
     url_defaults={u'package_type': u'dataset'}
 )
 ga_dataset.before_request(before_dataset_request)
-ga_dataset.add_url_rule(u'/new', methods=[u'GET'], view_func=dataset.CreateView.as_view('new'))
+ga_dataset.add_url_rule(u'/new', view_func=dataset.CreateView.as_view('new'))
 ga_dataset.add_url_rule(u'/<id>', methods=[u'GET'], view_func=dataset.read)
 
 
@@ -197,6 +204,11 @@ def before_resource_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         package_id = args.get('id', '')
+        resource_id = args.get('resource_id', '')
+
+        if resource_id == 'new':
+            return
+
         try:
             package_dict = tk.get_action('package_show')({}, {'id': package_id})
             org_title = package_dict.get('organization', {}).get('title')
@@ -217,6 +229,7 @@ ga_resource = Blueprint(
     url_defaults={u'package_type': u'dataset'}
 )
 ga_resource.before_request(before_resource_request)
+ga_resource.add_url_rule(u'/new', view_func=resource.CreateView.as_view('new'))
 ga_resource.add_url_rule(
     u'/<resource_id>',
     view_func=resource.read,
@@ -242,7 +255,7 @@ ga_datastore = Blueprint(
     url_prefix=u'/datastore',
 )
 ga_datastore.before_request(before_datastore_request)
-ga_datastore.add_url_rule("/dump/<resource_id>'", view_func=dump)
+ga_datastore.add_url_rule('/dump/<resource_id>', view_func=dump)
 
 
 def _post_analytics(

--- a/ckanext/googleanalytics/views.py
+++ b/ckanext/googleanalytics/views.py
@@ -137,16 +137,18 @@ def before_organization_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         org_id = args.get('id', '')
-        org_dict = tk.get_action('organization_show')({},{'id': org_id})
-        org_title = org_dict.get('title')
-        _post_analytics(
-            tk.c.user,
-            "CKAN Organization Page View",
-            "Organization",
-            "View",
-            org_title
-        )
-
+        try:
+            org_dict = tk.get_action('organization_show')({},{'id': org_id})
+            org_title = org_dict.get('title')
+            _post_analytics(
+                tk.c.user,
+                "CKAN Organization Page View",
+                "Organization",
+                "View",
+                org_title
+            )
+        except (tk.ObjectNotFound, tk.NotAuthorized):
+            pass
 
 ga_organization = Blueprint(
     u'organization_googleanalytics',
@@ -156,6 +158,7 @@ ga_organization = Blueprint(
                   u'is_organization': True}
 )
 ga_organization.before_request(before_organization_request)
+ga_organization.add_url_rule(u'/new', methods=[u'GET'], view_func=group.CreateGroupView.as_view('new'))
 ga_organization.add_url_rule(u'/<id>', methods=[u'GET'], view_func=group.read)
 
 
@@ -163,15 +166,19 @@ def before_dataset_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         package_id = args.get('id', '')
-        package_dict = tk.get_action('package_show')({}, {'id': package_id})
-        org_title = package_dict.get('organization', {}).get('title')
-        _post_analytics(
-            tk.c.user,
-            "CKAN Organization Page View",
-            "Organization",
-            "View",
-            org_title
-        )
+        if package_id and package_id != 'new':
+            try:
+                package_dict = tk.get_action('package_show')({}, {'id': package_id})
+                org_title = package_dict.get('organization', {}).get('title')
+                _post_analytics(
+                    tk.c.user,
+                    "CKAN Organization Page View",
+                    "Organization",
+                    "View",
+                    org_title
+                )
+            except (tk.ObjectNotFound, tk.NotAuthorized):
+                pass
 
 
 ga_dataset = Blueprint(
@@ -181,22 +188,26 @@ ga_dataset = Blueprint(
     url_defaults={u'package_type': u'dataset'}
 )
 ga_dataset.before_request(before_dataset_request)
-ga_dataset.add_url_rule(u'/<id>', view_func=dataset.read)
+ga_dataset.add_url_rule(u'/new', methods=[u'GET'], view_func=dataset.CreateView.as_view('new'))
+ga_dataset.add_url_rule(u'/<id>', methods=[u'GET'], view_func=dataset.read)
 
 
 def before_resource_request():
     if tk.request.method == 'GET':
         args = tk.request.view_args
         package_id = args.get('id', '')
-        package_dict = tk.get_action('package_show')({}, {'id': package_id})
-        org_title = package_dict.get('organization', {}).get('title')
-        _post_analytics(
-            tk.c.user,
-            "CKAN Organization Page View",
-            "Organization",
-            "View",
-            org_title
-        )
+        try:
+            package_dict = tk.get_action('package_show')({}, {'id': package_id})
+            org_title = package_dict.get('organization', {}).get('title')
+            _post_analytics(
+                tk.c.user,
+                "CKAN Organization Page View",
+                "Organization",
+                "View",
+                org_title
+            )
+        except (tk.ObjectNotFound, tk.NotAuthorized):
+            pass
 
 
 ga_resource = Blueprint(

--- a/ckanext/googleanalytics/views.py
+++ b/ckanext/googleanalytics/views.py
@@ -73,8 +73,10 @@ def download(id, resource_id, filename=None, package_type="dataset"):
         package_id = resource_dict.get('package_id')
         package_dict = tk.get_action('package_show')({}, {'id': package_id})
         package_name = package_dict.get('name')
-        organization_id = package_dict.get('organization').get('id')
-        organization_title = package_dict.get('organization').get('title')
+        organization_id = package_dict.get('organization', {}).get('id')
+        organization_title = package_dict.get('organization', {}).get('title')
+    except tk.ValidationError as error:
+        return tk.abort(400, error.message)
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return tk.abort(404, _('Resource not found'))
 
@@ -147,8 +149,8 @@ def before_organization_request():
                 "View",
                 org_title
             )
-        except (tk.ObjectNotFound, tk.NotAuthorized):
-            pass
+        except Exception as e:
+            log.debug(e)
 
 ga_organization = Blueprint(
     u'organization_googleanalytics',
@@ -177,9 +179,8 @@ def before_dataset_request():
                     "View",
                     org_title
                 )
-            except (tk.ObjectNotFound, tk.NotAuthorized):
-                pass
-
+            except Exception as e:
+                log.debug(e)
 
 ga_dataset = Blueprint(
     u'dataset_googleanalytics',
@@ -206,9 +207,8 @@ def before_resource_request():
                 "View",
                 org_title
             )
-        except (tk.ObjectNotFound, tk.NotAuthorized):
-            pass
-
+        except Exception as e:
+            log.debug(e)
 
 ga_resource = Blueprint(
     u'resource_googleanalytics',
@@ -235,7 +235,6 @@ def before_datastore_request():
             "Download",
             resource_id
         )
-
 
 ga_datastore = Blueprint(
     u'datastore_googleanalytics',

--- a/ckanext/googleanalytics/views.py
+++ b/ckanext/googleanalytics/views.py
@@ -20,6 +20,7 @@ CONFIG_HANDLER_PATH = "googleanalytics.download_handler"
 
 log = logging.getLogger(__name__)
 ga = Blueprint("google_analytics", "google_analytics")
+_ = tk._
 
 
 def action(logic_function, ver=api.API_MAX_VERSION):
@@ -66,13 +67,16 @@ def download(id, resource_id, filename=None, package_type="dataset"):
         log.debug("Use default CKAN callback for resource.download")
         handler = resource.download
 
-    resource_dict = tk.get_action('resource_show')({}, {'id': resource_id})
-    resource_name = resource_dict.get('name')
-    package_id = resource_dict.get('package_id')
-    package_dict = tk.get_action('package_show')({}, {'id': package_id})
-    package_name = package_dict.get('name')
-    organization_id = package_dict.get('organization').get('id')
-    organization_title = package_dict.get('organization').get('title')
+    try:
+        resource_dict = tk.get_action('resource_show')({}, {'id': resource_id})
+        resource_name = resource_dict.get('name')
+        package_id = resource_dict.get('package_id')
+        package_dict = tk.get_action('package_show')({}, {'id': package_id})
+        package_name = package_dict.get('name')
+        organization_id = package_dict.get('organization').get('id')
+        organization_title = package_dict.get('organization').get('title')
+    except (tk.ObjectNotFound, tk.NotAuthorized):
+        return tk.abort(404, _('Resource not found'))
 
     try:
         resource_alias = resource_id


### PR DESCRIPTION
This PR adds exception handling for NotFound and NotAuthorized errors.
The fix is to return a 400 or 404 status when users try to download a file that is no longer in CKAN or do not have permission to download.

For other events like viewing a dataset, resource, or organization the extension will catch all exception and pass so that the default controller or view can handle things.

This PR also fixes an issue where `new` is treated as an id instead of the route to create datasets or groups. To fix this we add url rules to point back to the default dataset view or group view.
