### PR TITLE
Fix empty googleanalytics.id support

### DIFF
--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
@@ -1,41 +1,38 @@
 {% block main %}
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{googleanalytics_id}}"></script>
-    <script>
-     window.dataLayer = window.dataLayer || [];
-     function gtag(){dataLayer.push(arguments);}
+    {% if googleanalytics_id and googleanalytics_id != 'ODC_GOOGLE_ANALYTICS_ID' %}
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{googleanalytics_id}}"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
 
-     {% block setup %}
-         gtag('set', 'linker');
+        {% block setup %}
+            gtag('set', 'linker');
 
-         gtag('js', new Date());
+            gtag('js', new Date());
 
-         gtag('config', '{{googleanalytics_id}}', {
-             anonymize_ip: true,
-             linker: {
-                 domains: {{ googleanalytics_linked_domains|tojson }}
-             }
-         });
-     {% endblock setup %}
+            gtag('config', '{{googleanalytics_id}}', {
+                anonymize_ip: true,
+                linker: {
+                    domains: {{ googleanalytics_linked_domains|tojson }}
+                }
+            });
+        {% endblock setup %}
 
-     {% block extra %}
-     {% endblock extra %}
+        {% block extra %}
+        {% endblock extra %}
 
-    </script>
+        </script>
+    {% endif %}
 
     {% with measurement_id = h.googleanalytics_opendata_measurement_id() %}
     {% if measurement_id %}
         <script async src="https://www.googletagmanager.com/gtag/js?id={{ measurement_id }}"></script>
         <script>
-            console.log('measurement_id', '{{ measurement_id }}');
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '{{ measurement_id }}');
-        </script>
-    {% else %}
-        <script>
-            console.log('No measurement_id found');
         </script>
     {% endif %}
     {% endwith %}

--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
@@ -27,10 +27,15 @@
     {% if measurement_id %}
         <script async src="https://www.googletagmanager.com/gtag/js?id={{ measurement_id }}"></script>
         <script>
+            console.log('measurement_id', '{{ measurement_id }}');
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '{{ measurement_id }}');
+        </script>
+    {% else %}
+        <script>
+            console.log('No measurement_id found');
         </script>
     {% endif %}
     {% endwith %}


### PR DESCRIPTION
I added this if validation:
{% if googleanalytics_id and googleanalytics_id != 'ODC_GOOGLE_ANALYTICS_ID' %}

So when there is no googleanalytics.id set, the code was send a message to googletagmanager with the id "ODC_GOOGLE_ANALYTICS_ID" which I guess is the default placeholder, and we don't want that to happen:

![image](https://github.com/user-attachments/assets/fd5c9e1d-a8c5-4426-bdbc-faab7008fbb2)
