### PR TITLE
Send measurement_id when tracking mode is gtm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,20 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.11", "2.10", 2.9]
+        include:
+          - ckan-version: "2.11"
+            ckan-image: "ckan/ckan-dev:2.11-py3.10"
+          - ckan-version: "2.10"
+            ckan-image: "ckan/ckan-dev:2.10-py3.10"
+          - ckan-version: "2.9"
+            ckan-image: "ckan/ckan-dev:2.9-py3.9"
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
-      image: ckan/ckan-dev:${{ matrix.ckan-version }}
+      image: ${{ matrix.ckan-image }}
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
@@ -46,17 +53,8 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install requirements for CKAN 2.9
-      if: matrix.ckan-version == '2.9'
-      run: |
-        pip install --upgrade setuptools==70.0.0
-        pip install -r requirements.txt
-        pip install -e .
-        # Replace default path to CKAN core config file with the one on the container
-        sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
-    - name: Install requirements for other CKAN versions
-      if: matrix.ckan-version != '2.9'
+    - uses: actions/checkout@v4
+    - name: Install requirements
       run: |
         pip install -r requirements.txt
         pip install -e .
@@ -76,6 +74,8 @@ jobs:
         ckan -c test.ini db upgrade -p googleanalytics
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.googleanalytics --cov-report xml:coverage.xml --disable-warnings ckanext/googleanalytics/tests
+    - name: Install unzip for SonarQube and cov
+      run: apt-get update && apt-get -y install unzip curl
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master
       with:

--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtag.html
@@ -25,15 +25,5 @@
         </script>
     {% endif %}
 
-    {% with measurement_id = h.googleanalytics_opendata_measurement_id() %}
-    {% if measurement_id %}
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{ measurement_id }}"></script>
-        <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '{{ measurement_id }}');
-        </script>
-    {% endif %}
-    {% endwith %}
+    {% include 'googleanalytics/snippets/_opendata_measurement_id.html' %}
 {% endblock %}

--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtm.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/_gtm.html
@@ -5,3 +5,5 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{googleanalytics_id}}');</script>
 <!-- End Google Tag Manager -->
+
+{% include 'googleanalytics/snippets/_opendata_measurement_id.html' %}

--- a/ckanext/googleanalytics/templates/googleanalytics/snippets/_opendata_measurement_id.html
+++ b/ckanext/googleanalytics/templates/googleanalytics/snippets/_opendata_measurement_id.html
@@ -1,0 +1,11 @@
+{% with measurement_id = h.googleanalytics_opendata_measurement_id() %}
+{% if measurement_id %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ measurement_id }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ measurement_id }}');
+    </script>
+{% endif %}
+{% endwith %}

--- a/ckanext/googleanalytics/tests/test_view.py
+++ b/ckanext/googleanalytics/tests/test_view.py
@@ -25,3 +25,14 @@ class TestCodeSnippets:
         snippet = _render_header(mode, tracking_id)
         resp = app.get("/about")
         assert six.ensure_str(snippet) in resp
+
+    def test_gtm_mode_includes_opendata_measurement_id(self, app, ckan_config):
+        """When tracking_mode is gtm and opendata_measurement_id is set,
+        the header must include the gtag snippet for that measurement ID."""
+        measurement_id = config.opendata_measurement_id()
+        if not measurement_id:
+            pytest.skip("googleanalytics.opendata_measurement_id not set")
+        snippet = _render_header("gtm", "GTM-123")
+        snippet_str = six.ensure_str(snippet)
+        assert "gtag/js?id={}".format(measurement_id) in snippet_str
+        assert "gtag('config', '{}')".format(measurement_id) in snippet_str

--- a/dev-requirements-2.9.txt
+++ b/dev-requirements-2.9.txt
@@ -1,4 +1,3 @@
-pytest<=6.0.2
 pytest-ckan
 pytest-factoryboy
 pytest-cov


### PR DESCRIPTION
# Description
Fix GTM mode so the Open Data measurement_id is sent.
Update the CI test workflow with versioned CKAN images, unified install steps, and SonarQube dependencies.